### PR TITLE
bugfix:`randomize` makes a string id; v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Current version (in development)
+
+* Breaking change: Bug fix: The `randomize` feature will set `.id` to a string, not a number, when the instance is created.
+
 ## v0.5.0 (2023-08-06)
 
 * Breaking change: Fixed bug causing `SpicyAutoField` and `SpicySmallAutoField` to inherit from `models.BigAutoField`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Current version (in development)
+## v0.6.0 (2023-08-20)
 
 * Breaking change: Bug fix: The `randomize` feature will set `.id` to a string, not a number, when the instance is created.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ In addition to all parameters you can provide a normal `AutoField`, each of the 
   - Example with padding: `user_0000008M0kX`
 - **`randomize`**: If `True`, the default value of a new record will be generated randomly using `secrets.randbelow()`. If `False` (the default), works just like a normal `AutoField` i.e. the default value comes from the database upon `INSERT`.
   - When `randomize` is set, an error will be thrown if `default` is also set, since `randomize` is essentially a special and built-in `default` function.
+  - Since `randomize` installs a special `default` function, a new but unsaved model instance will have a non-`None` value for `object.id` / `object.pk`. You must used `object._state.adding` to determine whether an instance is a new but unsaved object.
   - If you use this feature, be aware of its hazards: 
       - The generated ID may conflict with an existing row, with probability [determined by the birthday problem](https://en.wikipedia.org/wiki/Birthday_problem#Probability_table) (i.e. the column size and the size of the existing dataset).
       - A conflict can also arise if two processes generate the same value for `secrets.randbelow()` (i.e. if system entropy is identical or misconfigured for some reason).

--- a/django_spicy_id/tests/fields_test.py
+++ b/django_spicy_id/tests/fields_test.py
@@ -205,3 +205,16 @@ class TestFields(TestCase):
         model = models.HexModel_WithPadding
         o = model.objects.create(id=0x123)
         self.assertEqual("ex_0000000000000123", o.id)
+
+    @mock.patch("secrets.randbelow")
+    def test_randomize_sets_pk_to_a_string(self, mock_secrets_randbelow):
+        """Ensures that when `randomize` is used, the value set is a string not a number."""
+        model = models.Base62Model_WithRandomize
+
+        mock_secrets_randbelow.return_value = 1
+        o = model()
+        self.assertEqual("ex_2", o.pk)
+        self.assertTrue(o._state.adding)
+        o.save()
+        self.assertEqual("ex_2", o.pk)
+        self.assertFalse(o._state.adding)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-spicy-id"
-version = "0.5.0"
+version = "0.6.0"
 description = ""
 authors = ["mike wakerly <opensource@hoho.com>"]
 license = "MIT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-spicy-id
-version = 0.5.0
+version = 0.6.0
 description = Fancy ID fields for django models.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Technically a number was acceptable and is supported by the underlying field class. However it was at least unexpected to see a numeric value once (on create), as in:

```
>>> o = SomeModelWhereRandomizeIsEnabled()
>>> o.id
3735928559
>>> o.save()
>>> o.refresh_from_db()
>>> o.id
'ex_deadbeef`
```