### PR TITLE
Add workaround for model sometimes returning a numeric `.id` on create

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
           - "3.10"
           - "3.11"
         django-version:
-          - "django22"
           - "django32"
           - "django42"
         mysql-image:
@@ -72,7 +71,6 @@ jobs:
           - "3.10"
           - "3.11"
         django-version:
-          - "django22"
           - "django32"
           - "django42"
         postgres-image:
@@ -118,7 +116,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         django-version:
-          - "django22"
           - "django32"
           - "django42"
         python-version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Current version (in development)
+## v0.7.0 (2023-08-23)
 
-* Dropped support for Django 2.2.
+This version fixes a bug that affects Django 3.x installations and is recommended for those users.
+
+* Bugfix: Add workaround for a Django 3.x bug where a newly-saved instance's `.id` might be returned as a number, not a spicy string. (#6)
+* Breaking change: Dropped support for Django 2.2.
 * Updated target Django versions from `3.1 -> 3.2` and `4.1 -> 4.2`.
 * Updated integration tests to properly test against all Django versions (#7).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current version (in development)
 
-* Updated target Django versions from `3.1 -> 3.2` and `4.1 -> 4.2`
+* Dropped support for Django 2.2.
+* Updated target Django versions from `3.1 -> 3.2` and `4.1 -> 4.2`.
 * Updated integration tests to properly test against all Django versions (#7).
 
 ## v0.6.1 (2023-08-20)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ This package supports and is tested against the latest patch versions of:
 
 All database backends are tested with the latest versions of their drivers. SQLite is also tested on GitHub Actions' latest macOS virtual environment.
 
+**Note:** Django 4.x is recommended due to an [upstream bug](https://code.djangoproject.com/ticket/32442) that is present in 3.x. See [#6](https://github.com/mik3y/django-spicy-id/issues/6) for further details.
+
 ### Instructions
 
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For a more detailed look at this pattern, see Stripe's ["Object IDs: Designing A
 This package supports and is tested against the latest patch versions of:
 
 - **Python:** 3.8, 3.9, 3.10, 3.11
-- **Django:** 2.2, 3.2, 4.2
+- **Django:** 3.2, 4.2
 - **MySQL:** 5.7, 8.0
 - **PostgreSQL:** 9.5, 10, 11, 12
 - **SQLite:** 3.9.0+

--- a/django_spicy_id/tests/fields_test.py
+++ b/django_spicy_id/tests/fields_test.py
@@ -209,12 +209,12 @@ class TestFields(TestCase):
     @mock.patch("secrets.randbelow")
     def test_randomize_sets_pk_to_a_string(self, mock_secrets_randbelow):
         """Ensures that when `randomize` is used, the value set is a string not a number."""
-        model = models.Base62Model_WithRandomize
+        model = models.SpicyAutoFieldModel_WithRandomize
 
         mock_secrets_randbelow.return_value = 1
         o = model()
-        self.assertEqual("ex_2", o.pk)
+        self.assertEqual("ex_2", o.id)
         self.assertTrue(o._state.adding)
         o.save()
-        self.assertEqual("ex_2", o.pk)
+        self.assertEqual("ex_2", o.id)
         self.assertFalse(o._state.adding)

--- a/django_spicy_id/tests/models.py
+++ b/django_spicy_id/tests/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from django_spicy_id import SpicyBigAutoField
+from django_spicy_id import SpicyAutoField, SpicyBigAutoField
 
 
 class Model_WithDefaults(models.Model):
@@ -31,3 +31,7 @@ class Base62Model_WithRandomize(models.Model):
 
 class HexModel_WithRandomize(models.Model):
     id = SpicyBigAutoField("ex", primary_key=True, encoding="hex", randomize=True)
+
+
+class SpicyAutoFieldModel_WithRandomize(models.Model):
+    id = SpicyAutoField("ex", primary_key=True, encoding="hex", randomize=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-spicy-id"
-version = "0.6.1"
+version = "0.7.0"
 description = ""
 authors = ["mike wakerly <opensource@hoho.com>"]
 license = "MIT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-spicy-id
-version = 0.6.1
+version = 0.7.0
 description = Fancy ID fields for django models.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
 
 [testenv]
 deps =
-    django22: Django~=2.2.0
     django32: Django~=3.2.20
     django42: Django~=4.2.4
     mysql: mysqlclient


### PR DESCRIPTION
See issue #6.

The fix is a bit ugly (installs a signal handler; which runs in non-deterministic order alongside any others that have been installed), but I don't see a better one.